### PR TITLE
Stop displaying update and generation dates in footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,7 +2,6 @@
             <div class="row">
                 <div class="col-lg-12 footer">
                &copy;{{ site.time | date: "%Y"  }} {{site.company_name}}. All rights reserved. <br />
-{% if page.last_updated %}<span>Page last updated:</span> {{page.last_updated}}<br/>{% endif %} Site last generated: {{ site.time | date: "%b %-d, %Y"  }} <br />
                 </div>
             </div>
 </footer>


### PR DESCRIPTION
This information may be misleading. When date points to few
months ago it may suggest that documentation is outdated, while
it's perfectly up to date and just doesn't need editing.

Signed-off-by: Robert Baldyga <robert.baldyga@intel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-cas/open-cas.github.io/17)
<!-- Reviewable:end -->
