### PR TITLE
Fixed System Requirement Page Not Loading

### DIFF
--- a/_data/sidebars/opencas_sidebar.yml
+++ b/_data/sidebars/opencas_sidebar.yml
@@ -79,7 +79,7 @@ entries:
       output: web
 
     - title: Product Specifications and System Requirements
-      url: /guide_product_specs_requirements.html
+      url: /guide_system_requirements.html
       output: web
 
     - title: Installing CAS


### PR DESCRIPTION
The sidebar needed to reflect the new name for the page **guide_system_requirements.html** . This resulted in the System Requirements page not displaying.