### PR TITLE
Add extra flag cache_line_size to configuring page.

### DIFF
--- a/pages/open_cas_linux/guide_configuring.md
+++ b/pages/open_cas_linux/guide_configuring.md
@@ -142,6 +142,9 @@ Field details:
     -   *promotion_policy* allows the user to specify the promotion policy
         to be used for this cache, either always or nhit.
 
+    -   *cache_line_size* allows the user to specify the cache line size to be
+	used for this cache in kibibytes, either 4, 8, 16, 32, or 64.
+
         **NOTE:** During an upgrade, *opencas.conf* files with earlier formats
         will automatically be converted to the new format.
 


### PR DESCRIPTION
I read the code of `casctl`, it support optional field of `cache_line_size`.