### PR TITLE
Fix invalid block device type name in LVM doc

### DIFF
--- a/pages/open_cas_linux/guide_advanced_options.md
+++ b/pages/open_cas_linux/guide_advanced_options.md
@@ -160,7 +160,7 @@ Ensure Open CAS Linux devices are listed as acceptable block device types in
 >>   \# Advanced settings.  
 >>   \# List of pairs of additional acceptable block device types found  
 >>   \# in /proc/devices with maximum (non-zero) number of partitions.  
->>   *types = [ "cas_disk", 16 ]*
+>>   *types = [ "cas", 16 ]*
 
 After the LVM is configured and an Open CAS Linux device has been created (see
 [**Configuring CAS**](/guide_configuring.html) for further details) a physical


### PR DESCRIPTION
`cas_disk` registers its block device type under name `cas`, not `cas_disk`

Signed-off-by: Jan Musial <jan.musial@intel.com>